### PR TITLE
global: uniform file licence headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 language: python
 
 python:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,10 @@
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 include COPYING.txt
 include CHANGES.txt
 include README.rst

--- a/bin/run_workflow.py
+++ b/bin/run_workflow.py
@@ -1,5 +1,11 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
 
 import glob
 import sys
@@ -343,4 +349,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,11 @@
 #!/bin/sh
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 coverage run setup.py test
 coverage report -m

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
 
 try:
     from setuptools import setup
@@ -42,7 +50,7 @@ setup(
     tests_require=['nose', 'cloud', 'coverage'],
     install_requires = ['configobj>4.7.0'],
     long_description = """\
-Simple worfklows for Python
+Simple workflows for Python
 -------------------------------------
 
 Wofklow engine is a Finite State Machine with memory

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 import unittest
 import sys
 import os

--- a/tests/test_engine_interface.py
+++ b/tests/test_engine_interface.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 import unittest
 import sys
 import os

--- a/tests/test_engine_workflow.py
+++ b/tests/test_engine_workflow.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 import unittest
 import sys
 import os

--- a/tests/test_exgine.py
+++ b/tests/test_exgine.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 import unittest
 import sys
 import os

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 import unittest
 import sys
 import os

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,1 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 from .version import __version__

--- a/workflow/config.py
+++ b/workflow/config.py
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 import sys
 import os
 from configobj import Section, OPTION_DEFAULTS, ConfigObjError, ConfigObj
@@ -453,4 +462,3 @@ else:
 
 # This instance has access to all global/local config options
 config_reader = ConfigReader(basedir=__cfgdir)
-

--- a/workflow/engine.py
+++ b/workflow/engine.py
@@ -1,32 +1,11 @@
-
-#######################################################################################
-## Copyright (c) 2010-2011, 2014 CERN                                                ##
-## All rights reserved.                                                              ##
-##                                                                                   ##
-## Redistribution and use in source and binary forms, with or without modification,  ##
-## are permitted provided that the following conditions are met:                     ##
-##                                                                                   ##
-##     * Redistributions of source code must retain the above copyright notice,      ##
-##       this list of conditions and the following disclaimer.                       ##
-##     * Redistributions in binary form must reproduce the above copyright notice,   ##
-##       this list of conditions and the following disclaimer in the documentation   ##
-##       and/or other materials provided with the distribution.                      ##
-##     * Neither the name of the author nor the names of its contributors may be     ##
-##       used to endorse or promote products derived from this software without      ##
-##       specific prior written permission.                                          ##
-##                                                                                   ##
-## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND   ##
-## ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED     ##
-## WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.##
-## IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,  ##
-## INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    ##
-## BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,     ##
-## DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF   ##
-## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE   ##
-## OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED ##
-## OF THE POSSIBILITY OF SUCH DAMAGE.                                                ##
-##                                                                                   ##
-#######################################################################################
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2012, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
 
 import logging # we are not using the newseman logging to make this library independent
 import new

--- a/workflow/patterns/__init__.py
+++ b/workflow/patterns/__init__.py
@@ -1,3 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
+
 #basic flow commands
 from controlflow import STOP, BREAK, \
                         OBJ_JUMP_BWD, OBJ_JUMP_FWD, OBJ_NEXT, \
@@ -18,4 +27,3 @@ from utils import EMPTY_CALL, \
                     ERROR, TRY, RUN_WF, \
                     CALLFUNC, DEBUG_CYCLE, \
                     PROFILE
-

--- a/workflow/patterns/controlflow.py
+++ b/workflow/patterns/controlflow.py
@@ -1,31 +1,11 @@
-
-#######################################################################################
-## Copyright (c) 2010-2011, CERN                                                     ##
-## All rights reserved.                                                              ##
-##                                                                                   ##
-## Redistribution and use in source and binary forms, with or without modification,  ##
-## are permitted provided that the following conditions are met:                     ##
-##                                                                                   ##
-##     * Redistributions of source code must retain the above copyright notice,      ##
-##       this list of conditions and the following disclaimer.                       ##
-##     * Redistributions in binary form must reproduce the above copyright notice,   ##
-##       this list of conditions and the following disclaimer in the documentation   ##
-##       and/or other materials provided with the distribution.                      ##
-##     * Neither the name of the author nor the names of its contributors may be     ##
-##       used to endorse or promote products derived from this software without      ##
-##       specific prior written permission.                                          ##
-##                                                                                   ##
-## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND   ##
-## ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED     ##
-## WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.##
-## IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,  ##
-## INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    ##
-## BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,     ##
-## DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF   ##
-## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE   ##
-## OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED ##
-## OF THE POSSIBILITY OF SUCH DAMAGE.                                                ##
-#######################################################################################
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
 
 import threading
 import thread

--- a/workflow/patterns/utils.py
+++ b/workflow/patterns/utils.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2011, 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
 
 import inspect
 import traceback

--- a/workflow/version.py
+++ b/workflow/version.py
@@ -1,32 +1,11 @@
-
-#######################################################################################
-## Copyright (c) 2014 CERN                                                           ##
-## All rights reserved.                                                              ##
-##                                                                                   ##
-## Redistribution and use in source and binary forms, with or without modification,  ##
-## are permitted provided that the following conditions are met:                     ##
-##                                                                                   ##
-##     * Redistributions of source code must retain the above copyright notice,      ##
-##       this list of conditions and the following disclaimer.                       ##
-##     * Redistributions in binary form must reproduce the above copyright notice,   ##
-##       this list of conditions and the following disclaimer in the documentation   ##
-##       and/or other materials provided with the distribution.                      ##
-##     * Neither the name of the author nor the names of its contributors may be     ##
-##       used to endorse or promote products derived from this software without      ##
-##       specific prior written permission.                                          ##
-##                                                                                   ##
-## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND   ##
-## ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED     ##
-## WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.##
-## IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,  ##
-## INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    ##
-## BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,     ##
-## DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF   ##
-## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE   ##
-## OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED ##
-## OF THE POSSIBILITY OF SUCH DAMAGE.                                                ##
-##                                                                                   ##
-#######################################################################################
+# -*- coding: utf-8 -*-
+#
+# This file is part of Workflow.
+# Copyright (C) 2014 CERN.
+#
+# Workflow is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see COPYING.txt file for
+# more details.
 
 """
 Version information for workflow package.


### PR DESCRIPTION
- Adds header containing licence information to each source file.
- Amends copyright years for every source file based on its git
  commit log history.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
