### PR TITLE
tests: support for Python-3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,12 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
 
 install:
   - pip install --upgrade pip  --use-mirrors
-  - pip install cloud coverage --use-mirrors
+  - pip install coverage --use-mirrors
   - pip install pytest pytest-cache pytest-pep8 pytest-cov --use-mirrors
   - pip install coveralls --use-mirrors
   - pip install .

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-cov
-pytest-pep8

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Development Status :: 5 - Production/Stable',
         'Environment :: Other Environment',
         'Intended Audience :: Developers',
@@ -71,7 +72,7 @@ setup(
         'Topic :: Utilities',
     ],
     tests_require=[
-        'pytest', 'pytest-cache', 'pytest-cov', 'pytest-pep8', 'cloud',
+        'pytest', 'pytest-cache', 'pytest-cov', 'pytest-pep8',
         'coverage'
     ],
     cmdclass={'test': PyTest},

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = py26, py27, py33
+envlist = py26, py27, py33, py34
 
 [testenv]
-deps = -rrequirements-test.txt
+deps = pytest
+       pytest-cov
+       pytest-pep8
 commands = {envpython} -m pytest


### PR DESCRIPTION
- Adds Python 3.3 and 3.4 to `tox` and Travis CI tests.  (see #17)
- Comments out `cloud` that is not Python-3 friendly.  (see #15)
- Adds Python-3.4 to package classifiers.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
