### PR TITLE
global: spelling mistake fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ so I haven't looked for a better alternative.
 Details
 =======
 
-Wofklow engine is a Finite State Machine with memory
+Workflow engine is a Finite State Machine with memory.
 It is used to execute set of methods in a specified order.
 
 Here is a simple example of a configuration:
@@ -53,7 +53,7 @@ Here is a simple example of a configuration:
 
 You can probably guess what the processing pipeline does with tokens - the
 whole task is made of four steps and the whole configuration is just stored
-as a Python list. Every task is implemeted as a function that takes two objects:
+as a Python list. Every task is implemented as a function that takes two objects:
 
 * currently processed object
 * workflow engine instance
@@ -304,7 +304,7 @@ After the execution of task B, task C, and task D, task E can be executed
         return _synchronize
 
 
-Configuration (ie. what would admins write):
+Configuration (i.e. what would admins write):
 
 .. code-block:: text
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,8 +36,8 @@ Workflow is on PyPI so all you need is:
 Details
 =======
 
-Wofklow engine is a Finite State Machine with memory It is used to execute
-set of methods in a specified order.
+Workflow engine is a Finite State Machine with memory.  It is used to
+execute set of methods in a specified order.
 
 Here is a simple example of a configuration:
 
@@ -61,7 +61,7 @@ Here is a simple example of a configuration:
 
 You can probably guess what the processing pipeline does with tokens - the
 whole task is made of four steps and the whole configuration is just
-stored as a Python list. Every task is implemeted as a function that takes
+stored as a Python list. Every task is implemented as a function that takes
 two objects:
 
 * currently processed object
@@ -280,7 +280,7 @@ dead simple).
                     the simplest situation comes when you pass a list of callables
                     they will be simply executed in parallel.
                        But if you pass a list of callables (branch of callables)
-                    which is potentionally a new workflow, we will first create a
+                    which is potentially a new workflow, we will first create a
                     workflow engine with the workflows, and execute the branch in it
         @attention: you should never jump out of the synchronized branches
         """
@@ -316,7 +316,7 @@ dead simple).
         return _synchronize
 
 
-Configuration (ie. what would admins write):
+Configuration (i.e. what would admins write):
 
 .. code-block:: python
 
@@ -351,7 +351,7 @@ Here is a simple example of a configuration:
 
 You can probably guess what the processing pipeline does with tokens - the
 whole task is made of four steps and the whole configuration is just stored as
-a Python list. Every task is implemeted as a function that takes two objects:
+a Python list. Every task is implemented as a function that takes two objects:
 
 * currently processed object
 * workflow engine instance

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
 Simple workflows for Python
 -------------------------------------
 
-Wofklow engine is a Finite State Machine with memory
+Workflow engine is a Finite State Machine with memory.
 It is used to execute set of methods in a specified order.
 
 Here is a simple example of a configuration:
@@ -118,7 +118,7 @@ Here is a simple example of a configuration:
 
 You can probably guess what the processing pipeline does with tokens - the
 whole task is made of four steps and the whole configuration is just stored as
-a Python list. Every task is implemeted as a function that takes two objects:
+a Python list. Every task is implemented as a function that takes two objects:
 
    * currently processed object
    * workflow engine instance

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -7,6 +7,6 @@
 # under the terms of the Revised BSD License; see COPYING.txt file for
 # more details.
 
-"""Wofklow engine is a Finite State Machine with memory."""
+"""Workflow engine is a Finite State Machine with memory."""
 
 from .version import __version__

--- a/workflow/config.py
+++ b/workflow/config.py
@@ -407,7 +407,7 @@ class ConfigReader(object):
     def __str__(self):
         """Return textual representation of the current config.
 
-        It can be used for special purposes (ie. to save values
+        It can be used for special purposes (i.e. to save values
         somewhere and reload them -- however, they will be a simple
         dictionaries of textual values; without special powers. This
         class also does not provide ways to load such dumped values,

--- a/workflow/engine.py
+++ b/workflow/engine.py
@@ -78,7 +78,7 @@ class WorkflowMissingKey(WorkflowError):
 
 class GenericWorkflowEngine(object):
 
-    """Wofklow engine is a Finite State Machine with memory.
+    """Workflow engine is a Finite State Machine with memory.
 
     It is used to execute set of methods in a specified order.
 

--- a/workflow/patterns/utils.py
+++ b/workflow/patterns/utils.py
@@ -32,7 +32,7 @@ def RUN_WF(workflow, engine=None,
            pass_always=None,
            outkey='RUN_WF',
            reinit=False):
-    """Task for running other workflow - ie. new workflow engine will
+    """Task for running other workflow - i.e. new workflow engine will
     be created and the workflow run. The workflow engine is garbage
     collected together with the function. Therefore you can run the
     function many times and it will reuse the already-loaded WE. In fact
@@ -320,17 +320,17 @@ def DEBUG_CYCLE(stmt, setup=None,
     certain call - you can effectively reload modules and
     hotplug the new code, debug at runtime. The call is
     taking advantage of the internal python timeit module.
-    The parameters are the same as for timeit module - ie.
+    The parameters are the same as for timeit module - i.e.
 
-    :param stmt: string to evaluate (ie. "print sys")
-    :param setup: initialization (ie. "import sys")
+    :param stmt: string to evaluate (i.e. "print sys")
+    :param setup: initialization (i.e. "import sys")
 
     The debug_stopper is a callback that receives (eng, obj)
     *after* execution of the main call. If debug_stopper
     returns True, it means 'stop', don't continue.
 
     :param onerror: string (like the setup) which will
-        be appended to setup in case of error. Ie. if execution
+        be appended to setup in case of error. I.e. if execution
         failed, you can reload the module and try again. This
         gets fired only after an exception!
 


### PR DESCRIPTION
- Fixes various spelling mistakes, e.g. `Wofklow`.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
