### PR TITLE
SYNCHRONIZE will fall into an infinite loop

### DIFF
--- a/workflow/patterns/controlflow.py
+++ b/workflow/patterns/controlflow.py
@@ -395,7 +395,7 @@ def SYNCHRONIZE(*args, **kwargs):
                 new_eng.setWorkflow(func)
                 queue.put(lambda: new_eng.process([obj]))
             else:
-                queue.put(lambda: func(obj, eng))
+                queue.put(lambda func=func:func(obj, eng))
 
         # wait on the queue until everything has been processed
         queue.join_with_timeout(timeout)

--- a/workflow/patterns/controlflow.py
+++ b/workflow/patterns/controlflow.py
@@ -492,3 +492,4 @@ class MySpecialThread(threading.Thread):
     def run(self):
         call = self.itemq.get()
         call()
+        self.itemq.task_done()


### PR DESCRIPTION
firstly, SYNCHRONIZE will fall into an infinite loop without self.itemq.task_done(); secondly, lambda expression in for loop causes functions in queue point to the same fuction because of python late binding.